### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Example/Pods/Masonry/README.md
+++ b/Example/Pods/Masonry/README.md
@@ -1,4 +1,4 @@
-#Masonry [![Build Status](https://travis-ci.org/Masonry/Masonry.svg?branch=master)](https://travis-ci.org/Masonry/Masonry) [![Coverage Status](https://coveralls.io/repos/cloudkite/Masonry/badge.png?branch=master)](https://coveralls.io/r/cloudkite/Masonry?branch=master)
+# Masonry [![Build Status](https://travis-ci.org/Masonry/Masonry.svg?branch=master)](https://travis-ci.org/Masonry/Masonry) [![Coverage Status](https://coveralls.io/repos/cloudkite/Masonry/badge.png?branch=master)](https://coveralls.io/r/cloudkite/Masonry?branch=master)
 
 Masonry is a light-weight layout framework which wraps AutoLayout with a nicer syntax. Masonry has its own layout DSL which provides a chainable way of describing your NSLayoutConstraints which results in layout code that is more concise and readable.
 Masonry supports iOS and Mac OS X.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ DKFilterView *filterView = [[DKFilterView alloc] initWithFrame:self.view.frame];
 [self.view addSubview:filterView];
 [filterView setFilterModels:@[model]];
 ```
-###Customization
+### Customization
 
 Implement `DKFilterViewDelegate` to customize your own header view or click behavior.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
